### PR TITLE
Fix optional max_tokens in LLM client

### DIFF
--- a/app/clients/llm.py
+++ b/app/clients/llm.py
@@ -34,15 +34,10 @@ class LLMClient:
         }
 
         # Добавляем max_tokens если указан
-        if self._settings.llm_max_tokens:
+        if self._settings.llm_max_tokens is not None:
             create_params["max_tokens"] = self._settings.llm_max_tokens
 
-        response = await self._client.chat.completions.create(
-            model=create_params["model"],
-            messages=create_params["messages"],  # type: ignore
-            temperature=create_params["temperature"],
-            max_tokens=create_params.get("max_tokens"),
-        )
+        response = await self._client.chat.completions.create(**create_params)
 
         # Валидация ответа
         if not response.choices:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -96,12 +96,11 @@ async def test_optional_max_tokens():
     llm_client = LLMClient(mock_client, settings)
     await llm_client.ask("Test question")
 
-    # Проверяем что max_tokens передается как None
+    # Проверяем что max_tokens не передается, если значение не задано
     mock_client.chat.completions.create.assert_called_once_with(
         model="gpt-4o-mini",
         messages=[{"role": "user", "content": "Test question"}],
         temperature=0.5,
-        max_tokens=None,
     )
 
 


### PR DESCRIPTION
## Summary
- avoid sending `max_tokens=None` to OpenAI client
- update tests to match new behaviour

## Testing
- `ruff check`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6848abeedc94832fa47c81fecc886f7e